### PR TITLE
Don't post title if URL matches ignore patterns

### DIFF
--- a/lib/lita/handlers/web_title.rb
+++ b/lib/lita/handlers/web_title.rb
@@ -3,6 +3,8 @@ require "nokogiri"
 module Lita
   module Handlers
     class WebTitle < Handler
+      config :ignore_patterns, types: [String, Array]
+      
       URI_PROTOCOLS = %w( http https )
       route(URI.regexp(URI_PROTOCOLS), :parse_uri_request, help: {
         "URL" => "Responds with the title of the web page at URL"
@@ -10,6 +12,11 @@ module Lita
 
       def parse_uri_request(request)
         requestUri = URI::extract(request.message.body, URI_PROTOCOLS).first
+        if config.ignore_patterns.kind_of?(String) then
+          Array(config.ignore_patterns)
+        end
+        re = Regexp.union(%r(#{config.ignore_patterns}))
+        return if requestUri.match(re)
         result = parse_uri(requestUri)
         request.reply(result.delete("\n").strip) unless result.nil?
       end


### PR DESCRIPTION
This adds optional support to ignore certain URLs.  If you're using JIRA to post to hipchat, you don't need lita to tell you the title of the URI, as it's already there.  Same goes for NewRelic and other integrations where a non-human is posting URL's to a room.