### PR TITLE
Fix for using an array of patterns in ignore_patterns

### DIFF
--- a/lib/lita/handlers/web_title.rb
+++ b/lib/lita/handlers/web_title.rb
@@ -12,7 +12,7 @@ module Lita
 
       def parse_uri_request(request)
         requestUri = URI::extract(request.message.body, URI_PROTOCOLS).first
-        if config.ignore_patterns
+        if config.ignore_patterns then
           if config.ignore_patterns.kind_of?(String) then
             Array(config.ignore_patterns)
           end

--- a/lib/lita/handlers/web_title.rb
+++ b/lib/lita/handlers/web_title.rb
@@ -12,11 +12,14 @@ module Lita
 
       def parse_uri_request(request)
         requestUri = URI::extract(request.message.body, URI_PROTOCOLS).first
-        if config.ignore_patterns.kind_of?(String) then
-          Array(config.ignore_patterns)
+        if config.ignore_patterns
+          if config.ignore_patterns.kind_of?(String) then
+            Array(config.ignore_patterns)
+          end
+          config.ignore_patterns.each do |pattern|
+            return if requestUri.match(%r{#{pattern}})
+          end
         end
-        re = Regexp.union(%r(#{config.ignore_patterns}))
-        return if requestUri.match(re)
         result = parse_uri(requestUri)
         request.reply(result.delete("\n").strip) unless result.nil?
       end

--- a/spec/lita/handlers/web_title_spec.rb
+++ b/spec/lita/handlers/web_title_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe Lita::Handlers::WebTitle, lita_handler: true do
+  before :each do
+    registry.config.handlers.web_title.tap do |config|
+      config.ignore_patterns = ["example.com","github.com"]
+    end
+  end
+
   let(:robot) { Lita::Robot.new(registry) }
   subject(:handler) { described_class.new(robot) }
 
@@ -24,7 +30,13 @@ describe Lita::Handlers::WebTitle, lita_handler: true do
       send_command('This is the logo https://www.google.com/images/srpr/logo11w.png')
       expect(replies.last).to be_nil
     end
-  end
+
+    it 'ignores example.com links' do
+      send_command('I hate http://www.example.com/')
+      expect(replies.last).to be_nil
+    end
+
+   end
 
   describe '.parse_uri' do
     it 'returns the title' do


### PR DESCRIPTION
It seems my prior pull request worked when setting ignore_patterns to a string, but caused the handler to not work on any links at all when ignore_patterns was set to an array.  Rather than using Regexp.union which was new to me and hard to troubleshoot, I just iterate over the array now.

Oh, and I added a test for this, like I should have the first time :)
